### PR TITLE
Feat: 추가 top-nav 컴포넌트

### DIFF
--- a/src/assets/icon/icon-arrow-left.svg
+++ b/src/assets/icon/icon-arrow-left.svg
@@ -1,0 +1,4 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.4168 11H4.5835" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.0002 17.4167L4.5835 11L11.0002 4.58337" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/icon-more-vertical.svg
+++ b/src/assets/icon/icon-more-vertical.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" fill="#767676" stroke="#767676" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6C12.5523 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5C11 5.55228 11.4477 6 12 6Z" fill="#767676" stroke="#767676" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z" fill="#767676" stroke="#767676" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/icon-search.svg
+++ b/src/assets/icon/icon-search.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 19C15.4183 19 19 15.4183 19 11C19 6.58172 15.4183 3 11 3C6.58172 3 3 6.58172 3 11C3 15.4183 6.58172 19 11 19Z" stroke="#767676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.9999 21L16.6499 16.65" stroke="#767676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import Button from "../buttons/button";
+import "./navbar.css";
+
+export const BasicNav = () => {
+  return (
+    <div className="nav">
+      <button className="arrowButton">
+        <span className="a11yHidden">뒤로가기</span>
+      </button>
+      <button className="moreButton">
+        <span className="a11yHidden">더보기</span>
+      </button>
+    </div>
+  );
+};
+
+export const SearchNav = () => {
+  return (
+    <div className="nav">
+      <button className="arrowButton">
+        <span className="a11yHidden">뒤로가기</span>
+      </button>
+      <input className="searchInput" type="text" value="계정 검색"/>
+    </div>
+  );
+}; 
+
+export const MainNav = (props) => {
+  return (
+    <div className="nav">
+      <p className="mainTitle">{props.title}</p>
+      <button className="searchButton">
+        <span className="a11yHidden">검색하기</span>
+      </button>
+    </div>
+  );
+}; 
+
+export const UploadNav = () => {
+  return (
+    <div className="nav">
+      <button className="arrowButton">
+        <span className="a11yHidden">뒤로가기</span>
+      </button>
+      <Button className="button ms disabled uploadButton">저장</Button>
+    </div>
+  );
+};
+
+export const ChatNav = () => {
+  return (
+    <div className="nav">
+      <button className="arrowButton">
+        <span className="a11yHidden">뒤로가기</span>
+      </button>
+      <p className="chatTitle">애월읍 위니브 감귤농장</p>
+      <button className="moreButton">
+        <span className="a11yHidden">더보기</span>
+      </button>
+    </div>
+  );
+};

--- a/src/components/Navbar/navbar.css
+++ b/src/components/Navbar/navbar.css
@@ -1,0 +1,57 @@
+.nav {
+  width: 390px;
+  height: 48px;
+  border-bottom: 0.5px solid #DBDBDB;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+}
+
+.arrowButton {
+  width: 22px;
+  height: 22px;
+  margin-left: 16px;
+  background: url(../../assets/icon/icon-arrow-left.svg) no-repeat;
+}
+
+.moreButton {
+  width: 24px;
+  height: 24px;
+  margin: 0 12px 0 auto;
+  background: url(../../assets/icon/icon-more-vertical.svg) no-repeat;
+}
+
+.searchInput {
+  width: 315px;
+  height: 32px;
+  margin: 0 19px 0 auto;
+  padding: 7px 16px;
+  border-radius: 32px;
+  background: #F2F2F2;
+  font-size: 14px;
+  font-weight: 400;
+  color: #C4C4C4;
+}
+
+.mainTitle {
+  margin-left: 16px;
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.searchButton { 
+  width: 24px;
+  height: 24px;
+  margin: 0 16px 0 auto;
+  background: url(../../assets/icon/icon-search.svg) no-repeat;
+}
+
+.chatTitle {
+  margin-left: 10px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.uploadButton {
+  margin: 0 19px 0 auto;
+}


### PR DESCRIPTION
<img width="300" alt="iShot_2022-07-05_15 34 46" src="https://user-images.githubusercontent.com/103087604/177265038-d0e13549-8825-49ce-9e23-3e37a2cf02e2.png">

[basic, search, main, upload, chat] nav 추가했습니다.
아래와 같이 컴포넌트 사용이 가능합니다. (App.js를 예시로 적용했습니다)

```jsx
import { BasicNav, SearchNav, MainNav, UploadNav, ChatNav } from "./components/Navbar/Navbar";

function App() {
    return (
      <>
        <BasicNav />
        <SearchNav />
        <MainNav title={"데브북스 피드"}/>
        <UploadNav />
        <ChatNav />
      </>
    )
}
```

close #3 