### PR TITLE
Feat: 추가 modal component

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import "./modal.css";
+
+export default function Modal(props) {
+  return (
+    <div className="modalWrap">
+      <ul className="modalBody">
+        <span className="modalBar"></span>
+        {props.children}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -1,0 +1,28 @@
+.modalWrap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modalBody {
+  position: absolute;
+  bottom: 0px;
+  width: 100%;
+  background-color: #fff;
+  border-radius: 10px 10px 0 0;
+  padding: 36px 0 10px;
+}
+
+.modalBody .modalBar {
+  position: absolute;
+  width: 50px;
+  height: 4px;
+  background-color: #dbdbdb;
+  border-radius: 5px;
+  top: 16px;
+  left: 50%;
+  transform: translate(-50%);
+}

--- a/src/components/ModalContent/ModalContent.jsx
+++ b/src/components/ModalContent/ModalContent.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import "./modalContent.css";
+
+export default function ModalContent(props) {
+  return (
+    <li className="modalList">
+      <button type="button" className="modalTxtBtn" onClick={props.onClick}>
+        {props.txt}
+      </button>
+    </li>
+  );
+}

--- a/src/components/ModalContent/modalContent.css
+++ b/src/components/ModalContent/modalContent.css
@@ -1,0 +1,14 @@
+.modalList {
+  padding-left: 26px;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.modalList .modalTxtBtn {
+  width: 100%;
+  height: 46px;
+  padding: 0;
+  background-color: transparent;
+  text-align: left;
+}


### PR DESCRIPTION
<img width="708" alt="스크린샷 2022-07-19 오전 11 44 05" src="https://user-images.githubusercontent.com/102580289/179653066-dd7b6c9a-54e7-444d-9474-190999c990d1.png">
<img width="386" alt="스크린샷 2022-07-19 오전 11 44 21" src="https://user-images.githubusercontent.com/102580289/179653111-259fe252-eb33-4ef3-8f5d-28336c36b835.png">

여러 페이지에 사용될 수 있도록 모달창을 컴포넌트로 만들었습니다.
페이지마다 모달창안에 들어가는 내용과 갯수가 달라서 
모달창 내용부분도 따로 컴포넌트로 만들었습니다.

close #93 