### PR TITLE
Docs: 변경 ProfileInfo 컴포넌트

### DIFF
--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,24 +1,92 @@
 import React from "react";
 import "./profileInfo.css";
 import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
 
-function ProfileInfo(props) {
+function ProfileInfo() {
+  const [username, setUsername] = useState("");
+  const [accountname, setAccountname] = useState("");
+  const [intro, setIntro] = useState("");
+  const [userImg, setUserImg] = useState("");
+  const [following, setFollowing] = useState("");
+  const [follower, setFollower] = useState("");
+
+  const url = "https://mandarin.api.weniv.co.kr";
+  const token = window.localStorage.getItem("token");
+  const accountName = window.localStorage.getItem("accountname");
+
+  const init = {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-type": "application/json",
+    },
+  };
+
+  useEffect(() => {
+    profile();
+    followingCount();
+    followerCount();
+  }, []);
+
+   // 프로필
+   const profile = async () => {
+    const profilePath = `/profile/${accountName}`;
+
+    try {
+      const res = await fetch(url + profilePath, init);
+      const json = await res.json();
+      setUsername(json.profile.username);
+      setAccountname(json.profile.accountname);
+      setIntro(json.profile.intro);
+      setUserImg(json.profile.image);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  // 팔로잉
+  const followingCount = async () => {
+    const followingPath = `/profile/${accountName}/following`;
+
+    try {
+      const res = await fetch(url + followingPath, init);
+      const json = await res.json();
+      setFollowing(json.length);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  // 팔로워
+  const followerCount = async () => {
+    const followerPath = `/profile/${accountName}/follower`;
+
+    try {
+      const res = await fetch(url + followerPath, init);
+      const json = await res.json();
+      setFollower(json.length);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="profileInfo">
       <div className="profileWrapper">
         <div className="follower">
-          <Link to="/followers">{props.follower}</Link>
+          <Link to="/followers">{follower}</Link>
           <p className="followText">followers</p>
         </div>
-        <img src={props.ProfileImg} className="profileImg" alt="" />
+        <img src={userImg} className="profileImg" alt="" />
         <div className="followings">
-          <Link to="/followings">{props.followings}</Link>
+          <Link to="/followings">{following}</Link>
           <p className="followText">followings</p>
         </div>
       </div>
-      <p className="profileName">{props.name}</p>
-      <p className="profileId">{props.id}</p>
-      <p className="profileDecript">{props.description}</p>
+      <p className="profileName">{username}</p>
+      <p className="profileId">{`@` + accountname}</p>
+      <p className="profileDecript">{intro}</p>
     </div>
   );
 }

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "./profileInfo.css";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useState, useEffect } from "react";
 
 function ProfileInfo() {
@@ -11,9 +11,11 @@ function ProfileInfo() {
   const [following, setFollowing] = useState("");
   const [follower, setFollower] = useState("");
 
+  const location = useLocation();
   const url = "https://mandarin.api.weniv.co.kr";
   const token = window.localStorage.getItem("token");
-  const accountName = window.localStorage.getItem("accountname");
+  // const accountName = window.localStorage.getItem("accountname");
+  const accountName = checkAccountName();
 
   const init = {
     method: "GET",
@@ -69,6 +71,14 @@ function ProfileInfo() {
     } catch (err) {
       console.error(err);
     }
+  };
+
+  // accountName 체크
+  const checkAccountName = () => {
+    const accountName = location.search.split("id=")[1]
+      ? location.search.split("id=")[1]
+      : localStorage.getItem("accountname");
+    return accountName;
   };
 
   return (

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import "./profileInfo.css";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 
-function ProfileInfo() {
+function ProfileInfo(props) {
   const [username, setUsername] = useState("");
   const [accountname, setAccountname] = useState("");
   const [intro, setIntro] = useState("");
@@ -11,11 +11,9 @@ function ProfileInfo() {
   const [following, setFollowing] = useState("");
   const [follower, setFollower] = useState("");
 
-  const location = useLocation();
   const url = "https://mandarin.api.weniv.co.kr";
   const token = window.localStorage.getItem("token");
-  // const accountName = window.localStorage.getItem("accountname");
-  const accountName = checkAccountName();
+  const accountName = props.accountName;
 
   const init = {
     method: "GET",
@@ -31,8 +29,8 @@ function ProfileInfo() {
     followerCount();
   }, []);
 
-   // 프로필
-   const profile = async () => {
+  // 프로필
+  const profile = async () => {
     const profilePath = `/profile/${accountName}`;
 
     try {
@@ -71,14 +69,6 @@ function ProfileInfo() {
     } catch (err) {
       console.error(err);
     }
-  };
-
-  // accountName 체크
-  const checkAccountName = () => {
-    const accountName = location.search.split("id=")[1]
-      ? location.search.split("id=")[1]
-      : localStorage.getItem("accountname");
-    return accountName;
   };
 
   return (

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import "./profileInfo.css";
-import ProfileImg from "../../assets/basic-profile-img.svg";
 
 function ProfileInfo(props) {
   return (
@@ -10,7 +9,7 @@ function ProfileInfo(props) {
           <p>{props.follower}</p>
           <p className="followText">followers</p>
         </div>
-        <img src={ProfileImg} alt="" />
+        <img src={props.ProfileImg} className="profileImg" alt="" />
         <div className="followings">
           <p>{props.followings}</p>
           <p className="followText">followings</p>

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,17 +1,18 @@
 import React from "react";
 import "./profileInfo.css";
+import { Link } from "react-router-dom";
 
 function ProfileInfo(props) {
   return (
     <div className="profileInfo">
       <div className="profileWrapper">
         <div className="follower">
-          <p>{props.follower}</p>
+          <Link to="/followers">{props.follower}</Link>
           <p className="followText">followers</p>
         </div>
         <img src={props.ProfileImg} className="profileImg" alt="" />
         <div className="followings">
-          <p>{props.followings}</p>
+          <Link to="/followings">{props.followings}</Link>
           <p className="followText">followings</p>
         </div>
       </div>

--- a/src/components/ProfileInfo/profileInfo.css
+++ b/src/components/ProfileInfo/profileInfo.css
@@ -50,3 +50,10 @@
   font-size: 14px;
   font-weight: 400;
 }
+
+.profileImg {
+  width: 110px;
+  height: 110px;
+  border-radius: 100%;
+  object-fit: cover;
+}


### PR DESCRIPTION
<img width="289" alt="iShot_2022-07-20_00 00 29" src="https://user-images.githubusercontent.com/103087604/179785524-28ac10dd-9294-475c-bc0c-8fcb461f6153.png">

- 프로필 이미지 데이터를 props로 받아오도록 수정했습니다.
- 이미지 css 속성을 추가했습니다.
- 팔로워 및 팔로잉 수를 클릭하면 팔로워, 팔로잉 목록이 표시 되도록 Link 속성을 추가했습니다.
- **추가**: 컴포넌트 자체에서 사용자 데이터를 API에서 받아오도록 수정했습니다. 
- **추가**: accountName 값을 부모요소인 MyProfile, YourProfile에서 props로 전달하도록 수정했습니다.