### PR TITLE
Feat: 추가 포스트 이미지 프리뷰 컴포넌트

### DIFF
--- a/src/components/ImgPreview/ImgPreveiw.jsx
+++ b/src/components/ImgPreview/ImgPreveiw.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import deleteButton from '../../assets/icon/icon-delete.svg';
+
+const ImgPreview = (props) => {
+  const postUrl = props.postUrl;
+
+  return (
+    <>
+      {postUrl.map((file, index) => {
+        return (
+          <div className="postImgList" key={index}>
+            <button type="button">
+              <img className="deleteButton" src={deleteButton} alt="" />
+            </button>
+            <img className="postImg" src={file} alt="포스트 이미지 프리뷰" />
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+export default ImgPreview;


### PR DESCRIPTION
게시글 등록 페이지에서 사용할 포스트 이미지 프리뷰 컴포넌트를 만들었습니다.

삭제 기능을 추가하기 위해 버튼을 미리 넣어두었는데, 후에 삭제 기능 구현하면서 button요소에 props를 추가해줄 예정입니다. 


close: #105 