### PR TITLE
Feat: 추가 myProfile 상단 버튼 기능

### DIFF
--- a/src/pages/MyProfile/MyProfile.jsx
+++ b/src/pages/MyProfile/MyProfile.jsx
@@ -13,9 +13,11 @@ import postImg from "../../assets/post-img-example.png";
 import { useNavigate, useLocation } from "react-router-dom";
 import Modal from "../../components/Modal/Modal";
 import ModalContent from "../../components/ModalContent/ModalContent";
+import Alert from "../../components/Alert/Alert";
 
 function MyProfile() {
   const [navModal, setNavModal] = useState(false);
+  const [alert, setAlert] = useState(false);
 
   let navigate = useNavigate();
   const location = useLocation();
@@ -30,6 +32,7 @@ function MyProfile() {
 
   const accountName = checkAccountName();
 
+  // 상품 삭제
   const prodDelete = async (e) => {
     const url = "https://mandarin.api.weniv.co.kr";
     const token = window.localStorage.getItem("token");
@@ -49,6 +52,18 @@ function MyProfile() {
     } catch (error) {
       console.error(error);
     }
+  };
+
+  // 로그아웃
+  const handleLogout = () => {
+    window.localStorage.removeItem("accountname");
+    window.localStorage.removeItem("token");
+    navigate("/login");
+  };
+
+  // 설정 및 개인정보 버튼 누르면 myProfile로 이동
+  const nextMyProfile = () => {
+    navigate("/myProfile");
   };
 
   return (
@@ -93,9 +108,26 @@ function MyProfile() {
         }}
       >
         <Modal>
-          <ModalContent txt="설정 및 개인정보" />
-          <ModalContent txt="로그아웃" />
+          <ModalContent txt="설정 및 개인정보" onClick={nextMyProfile} />
+          <ModalContent
+            txt="로그아웃"
+            onClick={() => {
+              setAlert(true);
+              setNavModal(false);
+            }}
+          />
         </Modal>
+      </div>
+      <div className={alert ? "yourProfileAlert" : "disabledMyProfilePopup"}>
+        <Alert
+          message="로그아웃하시겠어요?"
+          cancel="취소"
+          confirm="로그아웃"
+          onClickCancel={() => {
+            setAlert(false);
+          }}
+          onClickConfirm={handleLogout}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION

<img width="261" alt="스크린샷 2022-07-21 오후 1 53 06" src="https://user-images.githubusercontent.com/102580289/180132508-e0bf2adc-2014-4b12-a91f-6aabc80dd1d9.png">


상단 navBar에 있는 버튼을 클릭하면 나오는 설정 및 개인정보, 로그아웃 기능을 구현했습니다.
* 설정 및 개인정보 -> myProfile 페이지로 이동 (myProfile페이지에서 클릭하는것이라 페이지 바뀌지 않습니다)
* 로그아웃 기능 -> localStorage에 accountname과 token 삭제

close #134 