### PR TITLE
Fix: 수정 포스트 이미지 스타일 코드

### DIFF
--- a/src/components/Content/content.css
+++ b/src/components/Content/content.css
@@ -50,6 +50,10 @@
 }
 .postMain .contentImg {
   margin: 16px 0 12px;
+  width: 304px;
+  height: 228px;
+  object-fit: cover;
+  border-radius: 10px;
 }
 
 .postBtnWrap {


### PR DESCRIPTION
싱글 포스트 페이지에서 보이는 포스트 이미지의 추가 스타일링 코드를 Content 컴포넌트 CSS파일에서 작성해주었습니다.
<img width="297" alt="Screen Shot 2022-07-21 at 14 14 03 PM" src="https://user-images.githubusercontent.com/92916958/180134808-4b5ec5d8-14a1-4736-a8aa-5f49a1f18580.png">

