### PR TITLE
Fix: 수정 이미지 2개 이상 업로드 시 문제

### DIFF
--- a/src/components/Content/Content.jsx
+++ b/src/components/Content/Content.jsx
@@ -29,7 +29,9 @@ export function Content(props) {
       </h2>
       <div className="postMain">
         <p className="contenttxt">{posttext}</p>
-        <img className="contentImg" src={postImg} alt="" />
+        {postImg.map((file, index) => {
+          return <img className="contentImg" src={file} alt="" key={index}/>;
+        })}
       </div>
       <div className="postBtnWrap">
         <span className="heartIcon">
@@ -82,7 +84,7 @@ export function Contents(props) {
         userName={item.author.username}
         userId={item.author.accountname}
         posttext={item.content}
-        postImg={item.image}
+        postImg={item.image.split(',')}
         heartNum={item.heartCount}
         commentNum={item.commentCount}
         postDate={item.createdAt}

--- a/src/pages/SinglePost/SinglePost.jsx
+++ b/src/pages/SinglePost/SinglePost.jsx
@@ -6,7 +6,7 @@ import PostComment from '../../components/PostComment/PostComment';
 import commentImgFirst from '../../assets/comment-img1.png';
 import commentImgSecond from '../../assets/comment-img2.png';
 import Topbar from '../../components/Topbar/Topbar';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export default function SinglePost() {
@@ -19,7 +19,7 @@ export default function SinglePost() {
   // 게시글 내용 상태
   const [contentText, setContentText] = useState('');
   // 게시글 이미지 상태
-  const [contentImg, setContentImg] = useState('');
+  const [contentImg, setContentImg] = useState([]);
   // 좋아요 count 상태
   const [likeCount, setLikeCount] = useState('');
   // 댓글 개수 상태
@@ -49,12 +49,11 @@ export default function SinglePost() {
         },
       });
       const json = await res.json();
-      console.log(json);
       setUserProfileImg(json.post.author.image);
       setUserName(json.post.author.username);
       setUserId(json.post.author.accountname);
       setContentText(json.post.content);
-      setContentImg(json.post.image);
+      setContentImg(json.post.image.split(','));
       setLikeCount(json.post.heartCount);
       setCommentCount(json.post.commentCount);
       setUploadDate(
@@ -66,7 +65,10 @@ export default function SinglePost() {
       );
     } catch (error) {}
   };
-  getPostInfo();
+  
+  useEffect(() => {
+    getPostInfo();
+  }, [])
 
   return (
     <div className="singlePostWrap">


### PR DESCRIPTION
이미지 2개 이상 업로드 시 이미지가 보이지 않는 문제를 수정했습니다.

이미지 주소를 넘길 때 배열로 넘기 지 않아서 두 개 이미지의 주소가 하나 이미지 태그 src에 한꺼번에 들어갔던 것이 원인이었습니다.

이미지 주소를 split메서드를 사용해 배열로 넘겨주었고, Content 컴포넌트에서 배열을 받아 map으로 이미지 리스트를 만들어주는 방식으로 해결했습니다.

싱글 포스트 페이지 렌더링 시 무한 렌더링이 되는 이슈를 발견하여 useEffect 훅 안에 게시글을 불러오는 함수를 넣어주어 최초 렌더링시에만 동작하도록 수정해주었습니다.

![무한렌더링](https://user-images.githubusercontent.com/92916958/180162858-4a93945f-e09e-4d5b-8bf4-5a7a962c1b58.gif)

close: #143 