### PR TITLE
Design: 수정 Splash, Login 페이지 배경 컬러, 로고 위치

### DIFF
--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import "./login.css";
 import logoImage from "../../assets/logo.svg";
 import logoNameKorean from "../../assets/logoNameKorean.svg";
-import logoNameEnglish from "../../assets/logoNameEnglish.svg";
 import { useNavigate } from "react-router-dom";
 import Topbar from "../../components/Topbar/Topbar";
 import Splash from "../Splash/Splash";
@@ -29,8 +28,7 @@ function LoginPage() {
           <Topbar />
           <div className="loginLogo">
             <img className="loginLogoImage2" src={logoImage} alt="데브북스" />
-            <img src={logoNameKorean} alt="데브북스" />
-            <img src={logoNameEnglish} alt="데브북스" />
+            <img src={logoNameKorean} className="logoKo" alt="데브북스" />
           </div>
           <article className="loginLink">
             <div className="loginKakao">카카오톡 계정으로 로그인</div>

--- a/src/pages/Login/login.css
+++ b/src/pages/Login/login.css
@@ -11,8 +11,9 @@
   position: relative;
   width: 390px;
   height: 844px;
-  background-color: #ea7f42;
+  background-color: #FFD66B;
   margin: 0 auto;
+  overflow: hidden;
 }
 
 .statusBar {
@@ -27,7 +28,7 @@
 
 .loginLogo {
   position: relative;
-  top: 150px;
+  top: 185px;
   width: 180px;
   display: flex;
   flex-direction: column;
@@ -38,7 +39,7 @@
 
 .loginLink {
   position: relative;
-  top: 250px;
+  top: 270px;
   width: 390px;
   height: 319px;
   overflow: hidden;

--- a/src/pages/Splash/Splash.jsx
+++ b/src/pages/Splash/Splash.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import logoImage from "../../assets/logo.svg";
 import logoNameKorean from "../../assets/logoNameKorean.svg";
-import logoNameEnglish from "../../assets/logoNameEnglish.svg";
 import Topbar from "../../components/Topbar/Topbar";
 import "./splash.css";
 
@@ -12,8 +11,7 @@ function Splash() {
         <Topbar />
         <div className="loginLogo">
           <img className="loginLogoImage" src={logoImage} alt="데브북스" />
-          <img src={logoNameKorean} alt="데브북스" />
-          <img src={logoNameEnglish} alt="데브북스" />
+          <img src={logoNameKorean} className="logoKo" alt="데브북스" />
         </div>
       </article>
     </>

--- a/src/pages/Splash/splash.css
+++ b/src/pages/Splash/splash.css
@@ -11,3 +11,7 @@
   animation: 점프 1s alternate infinite;
   margin: 20px;
 }
+
+.logoKo {
+  margin-top: 5px;
+} 


### PR DESCRIPTION
Splash와 Login 페이지의 배경 컬러, 로고 위치를 수정했습니다.
기존에 있었던 영어 로고는 일단 삭제했습니다.

<img width="250" alt="iShot_2022-07-22_10 15 43" src="https://user-images.githubusercontent.com/103087604/180342321-dbd50355-83d7-4021-89da-c2006b7fe73f.png">

