### PR TITLE
Feat: 추가 홈피드 팔로잉 계정 게시글 보여주는 기능

### DIFF
--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -9,12 +9,64 @@ import { useNavigate } from 'react-router-dom';
 import basicProfile from '../../assets/basic-profile.svg';
 import postImg from '../../assets/post-img-example.png';
 import postImg2 from '../../assets/post-img-example2.png';
+import { useState, useEffect } from 'react';
 
 import './homeFeed.css';
 
 export const HomeFeed = () => {
+  // 팔로워 게시글 목록 개수 상태
+  const [followerPost, setFollowerPost] = useState([]);
+
+  // 팔로워 게시글 목록 불러오기
+  const getFollowerPost = async () => {
+    const url = 'https://mandarin.api.weniv.co.kr';
+    const getPostPath = '/post/feed';
+    const token = localStorage.getItem('token');
+
+    try {
+      const res = await fetch(url + getPostPath, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      });
+
+      const json = await res.json();
+      setFollowerPost(json.posts);
+    } catch (error) {}
+  };
+  useEffect(() => {
+    getFollowerPost();
+  }, []);
+
   let navigate = useNavigate();
-  return (
+
+  return followerPost.length > 0 ? (
+    <section className="homeFeedData">
+      <Topbar />
+      <nav className="homeFeedNav">
+        <MainNav title={'데브북스 피드'} />
+      </nav>
+      <main className="homeFeedDataMain">
+        {followerPost.map((file, index) => {
+          return (
+            <Content
+              key={index}
+              userImg={file.author.image}
+              userName={file.author.username}
+              userId={file.author.accountname}
+              posttext={file.content}
+              postImg={[file.image]}
+              heartNum={file.heartCount}
+              commentNum={file.commentCount}
+              postDate={file.createdAt}
+            />
+          );
+        })}
+      </main>
+    </section>
+  ) : (
     <section className="homeFeed">
       <Topbar />
       <nav className="homeFeedNav">


### PR DESCRIPTION
내가 팔로우한 계정이 있을 때 홈피드에 팔로잉한 사람의 게시글을 보여주는 기능을 구현했습니다.

팔로우한 계정이 없는 경우 검색하기 페이지가 나옵니다.

![홈피드](https://user-images.githubusercontent.com/92916958/180364986-09f6d2dc-7f74-4b05-bba2-05861823db06.gif)

![홈피드2](https://user-images.githubusercontent.com/92916958/180365173-0a6dbe6e-7ac0-40db-be7c-f3edffd9a6e6.gif)

close: #157 
