### PR TITLE
Docs: 변경 홈피드 Navbar 검색 아이콘 클릭 시 계정 검색 페이지로 이동

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -47,10 +47,16 @@ export const SearchNav = () => {
 };
 
 export const MainNav = (props) => {
+  const navigate = useNavigate();
   return (
     <div className="nav">
       <p className="mainTitle">{props.title}</p>
-      <button className="searchButton">
+      <button
+        className="searchButton"
+        onClick={() => {
+          navigate("/SearchFeed");
+        }}
+      >
         <span className="a11yHidden">검색하기</span>
       </button>
     </div>


### PR DESCRIPTION
홈피드에서 검색 아이콘 클릭 시 계정 검색 페이지로 이동하도록 수정했습니다.

**홈피드** 

<img width="291" alt="iShot_2022-07-22_15 46 44" src="https://user-images.githubusercontent.com/103087604/180380448-eb83e9b0-5d7d-4291-8b2c-c2eafa813909.png">

<br>

**계정 검색**

<img width="293" alt="iShot_2022-07-22_15 46 59" src="https://user-images.githubusercontent.com/103087604/180380455-3def1884-0865-4a59-9b68-2c852d07e689.png">

