### PR TITLE
Feat: 추가 게시글의 유저 프로필 이미지 클릭하면 프로필 페이지로 이동

### DIFF
--- a/src/components/Content/Content.jsx
+++ b/src/components/Content/Content.jsx
@@ -35,6 +35,15 @@ export function Content(props) {
     });
   };
 
+  // 유저의 프로필 이미지 클릭하면 프로필 페이지로 이동
+  const moveProfile = () => {
+    if (userId === localStorage.getItem("accountname")){
+      navigate(`/myProfile`);
+    } else if (userId !== localStorage.getItem("accountname")) {
+      navigate(`/yourProfile?id=${userId}`)
+    }
+  }
+
   return (
     <section className="postContent">
       <h2 className="postUser">
@@ -42,6 +51,7 @@ export function Content(props) {
           className="postUserImg"
           src={userImg}
           alt="유저 기본 프로필 이미지"
+          onClick={moveProfile}
         />
         <div className="postUserInfo">
           <strong className="postUserName">{userName}</strong>

--- a/src/components/Content/content.css
+++ b/src/components/Content/content.css
@@ -15,6 +15,7 @@
   height: 42px;
   margin-right: 12px;
   border-radius: 100%;
+  cursor: pointer;
 }
 .postUserInfo {
   display: flex;

--- a/src/components/Content/content.css
+++ b/src/components/Content/content.css
@@ -48,9 +48,10 @@
   font-weight: 400;
   font-size: 14px;
   line-height: 18px;
+  margin-bottom: 16px;
 }
 .postMain .contentImg {
-  margin: 16px 0 12px;
+  margin: 0 0 12px;
   width: 304px;
   height: 228px;
   object-fit: cover;


### PR DESCRIPTION
게시글의 유저 프로필 이미지를 클릭하면 프로필 페이지로 이동하도록 기능을 추가했습니다.
본인이 작성한 게시글의 프로필 이미지를 클릭하면 나의 프로필 페이지로 이동합니다.

![Jul-22-2022 16-46-54](https://user-images.githubusercontent.com/103087604/180392474-70fac54e-2f74-4055-a026-2bdb056466f7.gif)

close #172