### PR TITLE
Fix: 수정 게시글이나 이미지 둘 중 하나만 작성시 업로드 안되는 문제

### DIFF
--- a/src/pages/PostUpload/PostUpload.jsx
+++ b/src/pages/PostUpload/PostUpload.jsx
@@ -69,9 +69,6 @@ export default function PostUpload() {
     }
   };
 
-  // 이미지 업로드 여부에 따라 버튼 활성화 하기 (곧 업데이트 예정)
-  
-
   // 이미지 서버로 보내기
   const uploadImg = async (file) => {
     const url = 'https://mandarin.api.weniv.co.kr';
@@ -100,6 +97,9 @@ export default function PostUpload() {
     let fileArray = [...files];
     fileArray.forEach(file => fileUrls.push(file));
 
+    // 이미지 업로드 시 버튼 활성화
+    setButtonActive('button ms uploadButton');
+    
     let previewUrl = [];
 
     if (files.length <= 3) {
@@ -133,7 +133,7 @@ export default function PostUpload() {
       for (const file of fileUrls) {
         imgUrls.push(url + '/' + (await uploadImg(file)));
       }
-      if (postContentText === '' || postImgUrl.length === 0) {
+      if (postContentText === '' && postImgUrl.length === 0) {
         alert('내용 또는 이미지를 입력해주세요.');
         return;
       } else {

--- a/src/pages/SinglePost/SinglePost.jsx
+++ b/src/pages/SinglePost/SinglePost.jsx
@@ -67,7 +67,11 @@ export default function SinglePost() {
       setUserName(json.post.author.username);
       setUserId(json.post.author.accountname);
       setContentText(json.post.content);
-      setContentImg(json.post.image.split(','));
+      if (json.post.image.split(',')[0] === '') {
+        setContentImg([]);
+      } else {
+        setContentImg(json.post.image.split(','));
+      }
       setLikeCount(json.post.heartCount);
       setCommentCount(json.post.commentCount);
       setUploadDate(


### PR DESCRIPTION
게시글이나 이미지 둘 중 하나만 작성하거나 업로드 했을 경우 포스팅 되지 않는 로직을 수정했습니다.

이미지만 등록해도 버튼이 활성화 될 수 있도록 로직을 추가했습니다. 

![게시글 솔로](https://user-images.githubusercontent.com/92916958/180395296-61378f34-dc0c-4761-9d47-73f4cf8d8acd.gif)

![이미지솔로](https://user-images.githubusercontent.com/92916958/180395350-585886f3-0ad8-4496-b075-2149b621af59.gif)

close: #174 
