### PR TITLE
Fix: 수정 댓글 작성 후 바로 반영안되는 이슈

### DIFF
--- a/src/pages/SinglePost/SinglePost.jsx
+++ b/src/pages/SinglePost/SinglePost.jsx
@@ -150,6 +150,7 @@ export default function SinglePost() {
           }),
         });
         const json = await res.json();
+        getCommentList();
         commentText.current.value = "";
       }
     } catch (error) {
@@ -172,13 +173,10 @@ export default function SinglePost() {
       const json = await res.json();
       const commentInfo = json.comments;
       setContent(commentInfo);
-      // console.log(json);
-      console.log(commentInfo);
       const commentAccountName = commentInfo.map(
         (item) => item.author.accountname
       ); // ['user1', 'user2', 'user2']
       const commentID = commentInfo.map((item) => item.id);
-      console.log(commentAccountName);
       setCommentUserId(commentAccountName);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
싱글 페이지에서 댓글을 작성하고 바로 반영안되는 이슈를 해결했습니다.

일단은 첫 렌더링 때 작성되었던 댓글을 불러오기 위해 useEffect를 사용해서 렌더링 시에 댓글을 불러오도록 하는 코드를 작성했습니다.
```
  useEffect(() => {
    getCommentList();
  }, []);

```
그리고 댓글을 서버로 보내는 함수 안 마지막에 댓글을 불러오는 함수를 한 번 더 실행시켜서 댓글을 서버로 보내는 즉시 페이지에도 반영될 수 있는 코드를 작성했습니다.
```
  // 댓글 작성
  const createComment = async () => {
    const commentReqPath = `/post/${postUniqueId}/comments`;

    try {
      if (commentText.current.value === "") {
        alert("댓글을 입력해주세요.");
      } else {
        const res = await fetch(url + commentReqPath, {
          method: "POST",
          headers: {
            Authorization: `Bearer ${token}`,
            "Content-type": "application/json",
          },
          body: JSON.stringify({
            comment: {
              content: commentText.current.value,
            },
          }),
        });
        const json = await res.json();
        getCommentList(); // 여기 부분
        commentText.current.value = "";
      }
    } catch (error) {
      console.log(error);
    }
  };
```

close: #188 