### PR TITLE
Fix: 수정 댓글 작성 & 게시 후 입력한 댓글 내용이 그대로 남아있는 문제

### DIFF
--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -1,20 +1,11 @@
 import './comment.css';
 import { forwardRef } from 'react';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export default Comment = forwardRef((props, ref) => {
-  // 댓글 작성 내용 상태
-  const [writeComment, setWriteComment] = useState('');
   // 댓글 버튼 활성화 상태
   const [buttonActive, setButtonActive] = useState('uploadComment');
 
-  useEffect(() => {
-    if(writeComment !== '') {
-      setButtonActive('activeCommentButton')
-    } else {
-      setButtonActive('uploadComment')
-    }
-  }, [writeComment])
 
   return (
     <form className="commentForm">
@@ -29,9 +20,10 @@ export default Comment = forwardRef((props, ref) => {
         id="comment"
         ref={ref}
         autoComplete="off"
-        value={writeComment}
         onChange={(e) => {
-          setWriteComment(e.target.value);
+          if(e.target.value !== '') {
+            setButtonActive('activeCommentButton');
+          }
         }}
       />
       <button className={buttonActive} type="button" onClick={props.click}>


### PR DESCRIPTION
댓글 작성하고 게시하면 작성한 댓글 내용이 그대로 남아있는 문제를 해결했습니다.

댓글을 작성하고 다시 지웠을 때 게시 버튼이 비활성화 되지 않습니다.
댓글을 게시한 후 게시 버튼이 계속 활성화 되어있는 이슈가 있습니다.


close: #194 