### PR TITLE
Feat: 수정 tab-menu css

### DIFF
--- a/src/pages/HomeFeed/homeFeed.css
+++ b/src/pages/HomeFeed/homeFeed.css
@@ -1,12 +1,9 @@
 .homeFeed {
-  position: relative;
-}
-
-.homeFeed {
   width: 390px;
   margin: 0 auto;
   text-align: center;
   background-color: #ffffff;
+  position: relative;
 }
 
 .homeFeedMain {

--- a/src/pages/MyProfile/myProfile.css
+++ b/src/pages/MyProfile/myProfile.css
@@ -18,9 +18,9 @@
 }
 
 .tabmenu {
-  position: fixed;
+  position: absolute;
   background-color: #fff;
-  top: 815px;
+  bottom: 0;
 }
 
 .MyProfileButtonWrapper {


### PR DESCRIPTION
1. my-profile의 하단 tab-menu가 부모의 위치에따라 움직이지 않아서 position: absolute를 주어서 부모의 위치가 기준이 되도록 하였습니다.
2. 홈피드 css에 클래스명 homeFeed가 두 번 적혀있어서 한번에 적어주었습니다.