### PR TITLE
Fix: 수정 팔로워 목록에서 팔로우 → 취소 버튼 변경 불가 현상

### DIFF
--- a/src/components/User/User.jsx
+++ b/src/components/User/User.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import "./user.css";
 import Button from "../Buttons/Button";
-import { useState } from "react";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 
 export const UserSearch = (props) => {
   return (

--- a/src/components/User/User.jsx
+++ b/src/components/User/User.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import "./user.css";
 import Button from "../Buttons/Button";
 import { useState } from "react";
+import { useEffect } from "react";
 
 export const UserSearch = (props) => {
   return (
@@ -17,6 +18,10 @@ export const UserSearch = (props) => {
 
 export const UserFollow = (props) => {
   const [isFollow, setIsFollow] = useState(false);
+
+  useEffect(() => {
+    getFollowStatus();
+  }, []);
 
   // 팔로우 한 사용자 -> 취소, 팔로우 하지 않은 사용자 -> 팔로우 버튼 표시
   const getFollowStatus = async () => {
@@ -41,7 +46,6 @@ export const UserFollow = (props) => {
       console.error("err", err);
     }
   };
-  getFollowStatus();
 
   const handleClick = () => {
     setIsFollow((isFollow) => !isFollow);


### PR DESCRIPTION
팔로워 목록에서 내가 팔로우 하지 않은 유저의 팔로우 → 취소 버튼 변경이 안되는 현상을 발견하여 수정했습니다.

useEffect를 사용해서 화면에 첫 렌더링 될 때 데이터를 불러오도록 코드를 수정했습니다.

```jsx
useEffect(() => {
  getFollowStatus();
}, []);
```

![Jul-26-2022 11-34-26](https://user-images.githubusercontent.com/103087604/180910728-34dab631-8800-4463-88f1-25ee5ace3352.gif)

<br>

close #204 