### PR TITLE
Fix: 수정 홈피드에서 게시글 이미지 안보이는 이슈

### DIFF
--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -57,7 +57,7 @@ const HomeFeed = () => {
               userName={file.author.username}
               userId={file.author.accountname}
               posttext={file.content}
-              postImg={[file.image]}
+              postImg={file.image.split(',')}
               heartNum={file.heartCount}
               commentNum={file.commentCount}
               postDate={file.createdAt}


### PR DESCRIPTION
홈 피드에서 팔로우한 사용자들의 게시글 이미지가 안보이는 이슈를 수정했습니다. 

close: #208 