### PR TITLE
Docs: 수정 프로필 페이지의 게시글 섹션 앨범형에서 이미지 클릭 시 해당 게시글로 이동

### DIFF
--- a/src/components/Album/Album.jsx
+++ b/src/components/Album/Album.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import "./album.css";
 
 function Album(props) {
+  let navigate = useNavigate();
   const [album, setAlbum] = useState([]);
   const url = "https://mandarin.api.weniv.co.kr";
   const token = window.localStorage.getItem("token");
@@ -35,10 +36,18 @@ function Album(props) {
       <div className="postWrapper">
         {album.map((item, index) => {
           return (
-            // 링크 추후 변경 
-            <Link to="/singlePost" key={index} >
-              <img src={item.image.split(',')[0]} alt="" />
-            </Link>
+            <img
+              key={index}
+              src={item.image.split(",")[0]}
+              alt=""
+              onClick={() => {
+                navigate("/singlePost", {
+                  state: {
+                    postId: item.id,
+                  },
+                });
+              }}
+            />
           );
         })}
       </div>

--- a/src/components/Album/album.css
+++ b/src/components/Album/album.css
@@ -10,4 +10,5 @@
   width: 114px;
   height: 114px;
   object-fit: cover;
+  cursor: pointer;
 }


### PR DESCRIPTION
나의 프로필, 사용자 프로필의 게시글 섹션 앨범형에서 이미지 클릭 시 해당 게시글로 이동하도록 로직을 추가했습니다.

![Jul-27-2022 11-25-47](https://user-images.githubusercontent.com/103087604/181147707-2a2f4579-4965-4c3a-a53b-18b6607e4474.gif)


close #223 