### PR TITLE
Fix: 댓글이 작성된 시간을 계산해 보여주는 로직 추가

### DIFF
--- a/src/components/PostComment/PostComment.jsx
+++ b/src/components/PostComment/PostComment.jsx
@@ -1,7 +1,21 @@
 // PostComment.jsx
-import "./postComment.css";
+import './postComment.css';
 
 export default function PostComment(props) {
+  
+  // 댓글 등록 시간 계산
+  function timeForComment(time) {
+    const postingDate = time.substring(0, time.length - 1);
+    const ms = Date.parse(postingDate);
+    const now = Date.now();
+    const gap = (now - ms) / 1000;
+    if (gap < 60) return '방금전';
+    else if (gap < 3600) return `${parseInt(gap / 60)}분 전`;
+    else if (gap < 86400) return `${parseInt(gap / 3600)}시간 전`;
+    else if (gap < 2592000) return `${parseInt(gap / 86400)}일 전`;
+    else return `${parseInt(gap / 2592000)}달 전`;
+  }
+
   return props.commentInfo.map((file, index) => {
     return (
       <li className="postComment" key={index}>
@@ -13,11 +27,7 @@ export default function PostComment(props) {
           />
           <strong className="commentUserName">{file.author.username}</strong>
           <span className="commentTime">
-            {file.createdAt
-              .slice(0, 11)
-              .replace("-", "년")
-              .replace("-", "월")
-              .replace("T", "일")}
+            {timeForComment(file.createdAt)}
           </span>
           <button
             className="moreCommentBtn"


### PR DESCRIPTION
싱글 포스트 페이지에서 댓글이 작성된 시간을 계산해 보여주는 로직을 추가했습니다. 

이전에는 작성된 년, 월, 일이 나왔지만 이젠 하루가 지나지 않은 경우 n분 전, n시간 전, n일 전, n달 전으로 표기됩니다. 