### PR TITLE
Fix: 수정 팔로워, 팔로잉 페이지에서 팔로우 버튼이 2번 렌더링 되는 현상

### DIFF
--- a/src/components/User/User.jsx
+++ b/src/components/User/User.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 import React from "react";
 import "./user.css";
 import Button from "../Buttons/Button";

--- a/src/components/User/User.jsx
+++ b/src/components/User/User.jsx
@@ -1,3 +1,5 @@
+/** @format */
+
 import React from "react";
 import "./user.css";
 import Button from "../Buttons/Button";
@@ -17,10 +19,9 @@ export const UserSearch = (props) => {
 };
 
 export const UserFollow = (props) => {
-  const accountName = props.id;
+  const { picture, name, id, button } = props;
   const myAccountName = localStorage.getItem("accountname");
-  const [isFollow, setIsFollow] = useState(false);
-  const [myAccount, setMyAccount] = useState(false);
+  const [isFollow, setIsFollow] = useState(button);
   let navigate = useNavigate();
 
   useEffect(() => {
@@ -40,15 +41,9 @@ export const UserFollow = (props) => {
     };
 
     try {
-      const resUserFollow = await fetch(`${url}/profile/${accountName}`, init);
+      const resUserFollow = await fetch(`${url}/profile/${id}`, init);
       const resUserFollowJson = await resUserFollow.json();
-      if (resUserFollowJson.profile.isfollow === false) {
-        setIsFollow(true);
-      }
-      // 나의 계정일 경우 팔로우 or 취소 버튼 표시 X
-      if (resUserFollowJson.profile.accountname === myAccountName) {
-        setMyAccount(true);
-      }
+      // console.log(resUserFollowJson);
     } catch (err) {
       console.error("err", err);
     }
@@ -56,10 +51,10 @@ export const UserFollow = (props) => {
 
   // 유저 클릭 시 해당 유저의 프로필 페이지로 이동
   const moveUserProfile = () => {
-    if (accountName === myAccountName) {
+    if (id === myAccountName) {
       navigate(`/myProfile`);
-    } else if (accountName !== myAccountName) {
-      navigate(`/yourProfile?id=${accountName}`);
+    } else if (id !== myAccountName) {
+      navigate(`/yourProfile?id=${id}`);
     }
   };
 
@@ -69,17 +64,17 @@ export const UserFollow = (props) => {
 
   return (
     <li className="userSearchList" onClick={moveUserProfile}>
-      <img src={props.picture} alt="유저 프로필 이미지" />
+      <img src={picture} alt="유저 프로필 이미지" />
       <div className="userInfo">
-        <strong className="userName">{props.name}</strong>
-        <strong className="userId">{props.id}</strong>
+        <strong className="userName">{name}</strong>
+        <strong className="userId">{id}</strong>
       </div>
-      <div className={myAccount ? "hidden" : "userFollowButton"}>
+      <div className={id === myAccountName ? "hidden" : "userFollowButton"}>
         <Button
-          className={isFollow ? "button sm" : "button sm active"}
+          className={isFollow ? "button sm active" : "button sm"}
           onClick={handleClick}
         >
-          {isFollow ? "팔로우" : "취소"}
+          {isFollow ? "취소" : "팔로우"}
         </Button>
       </div>
     </li>

--- a/src/pages/Followers/Followers.jsx
+++ b/src/pages/Followers/Followers.jsx
@@ -52,6 +52,7 @@ export const Followers = () => {
               picture={item.image}
               name={item.username}
               id={item.accountname}
+              button={item.isfollow}
             />
           );
         })}

--- a/src/pages/Followings/Followings.jsx
+++ b/src/pages/Followings/Followings.jsx
@@ -52,6 +52,7 @@ export const Followings = () => {
               picture={item.image}
               name={item.username}
               id={item.accountname}
+              button={item.isfollow}
             />
           );
         })}


### PR DESCRIPTION
팔로워, 팔로잉 페이지에서 팔로우 버튼이 2번 렌더링 되는 현상(취소 → 팔로우 출력)을 수정했습니다.

- 수정 전
![Jul-27-2022 16-01-48](https://user-images.githubusercontent.com/103087604/181182754-dc4be9f3-98a5-41a2-bade-758fbeee2581.gif)

- 수정 후 
![Jul-27-2022 16-57-29](https://user-images.githubusercontent.com/103087604/181193755-d3d9a01a-55c7-4a29-9f54-6057282cda69.gif)
![Jul-27-2022 16-57-50](https://user-images.githubusercontent.com/103087604/181193799-00a52d68-8cd6-49cd-81bc-1b09cf877c27.gif)

<br>

close #228 

